### PR TITLE
Improve `make_room.py` cli usability

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -149,7 +149,7 @@ files = [
 name = "click"
 version = "8.1.3"
 description = "Composable command line interface toolkit"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -164,7 +164,7 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
-category = "dev"
+category = "main"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 files = [
@@ -1038,4 +1038,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "bc331de3c34e6370fd594c45c1974e8b247d1586da0c40bea314b69111626227"
+content-hash = "313752431eb906d2f9df35af89d2d98ac958563dfce5dfd75d04a1955e39891a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ Pillow = ">=9.4.0"
 pillow-avif-plugin = ">=1.3.1"
 python-magic = ">=0.4.27"
 pymediainfo = ">=6.0.1"
+click = ">=8.1.3"
 
 [tool.poetry.group.dev.dependencies]
 bandit = ">=1.7.4"

--- a/src/make_room/make_room.py
+++ b/src/make_room/make_room.py
@@ -1,4 +1,5 @@
 import re
+import click
 import ffmpy
 import magic
 import os
@@ -56,13 +57,11 @@ def convert_to_h265(input_path, output_path):
     # print(f"Removed {input_path}")
 
 
+@click.command(context_settings={"show_default": True})
+@click.argument("path")
+@click.option("--dry-run", is_flag=True, default=True)
 def main(path: str, dry_run: bool = True) -> None:
-    """Converts all videos in the specified directory to h265.
-
-    Args:
-        path (str): target directory
-        dry_run (bool, optional): Defaults to True.
-    """
+    """Converts all videos in the specified directory to h265."""
 
     target_data_size = 2_000_000_000  # process a maximum of N bytes of data
     print(f"{'dry run...' if dry_run else 'real run...'}")
@@ -93,4 +92,4 @@ def main(path: str, dry_run: bool = True) -> None:
 
 
 if __name__ == "__main__":
-    main(sys.argv[1])  # requires an input path as the command line argument
+    main()  # requires an input path as the command line argument

--- a/src/make_room/make_room.py
+++ b/src/make_room/make_room.py
@@ -58,18 +58,22 @@ def convert_to_h265(input_path, output_path):
 
 
 @click.command(context_settings={"show_default": True})
-@click.argument("path")
-@click.option("--dry-run", is_flag=True, default=True)
-def main(path: str, dry_run: bool = True) -> None:
+@click.argument("directory")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="List files to convert, but don't actually convert anything.",
+)
+def main(directory: str, dry_run: bool) -> None:
     """Converts all videos in the specified directory to h265."""
 
     target_data_size = 2_000_000_000  # process a maximum of N bytes of data
     print(f"{'dry run...' if dry_run else 'real run...'}")
 
     actual_data_size = 0
-    # Walk through all the files in the specified directory.
-    for filename in os.listdir(path):
-        input_path = os.path.join(path, filename)
+    # Walk through all the entries in the specified directory.
+    for entry in os.listdir(directory):
+        input_path = os.path.join(directory, entry)
         # Ignore anything that isn't a file.
         if not os.path.isfile(input_path):
             continue

--- a/src/make_room/make_room.py
+++ b/src/make_room/make_room.py
@@ -57,21 +57,35 @@ def convert_to_h265(input_path, output_path):
 
 
 def main(path: str, dry_run: bool = True) -> None:
+    """Converts all videos in the specified directory to h265.
+
+    Args:
+        path (str): target directory
+        dry_run (bool, optional): Defaults to True.
+    """
+
     target_data_size = 2_000_000_000  # process a maximum of N bytes of data
     print(f"{'dry run...' if dry_run else 'real run...'}")
 
     actual_data_size = 0
+    # Walk through all the files in the specified directory.
     for filename in os.listdir(path):
         input_path = os.path.join(path, filename)
+        # Ignore anything that isn't a file.
         if not os.path.isfile(input_path):
             continue
         try:
+            # Only process videos that aren't already encoded with CRF.
             if is_video(input_path) and not encoded_with_crf(input_path):
+                # Print the input file.
                 print(f"Input: {input_path} ({formatted_size(input_path)})")
+                # If we're not doing a dry run, actually convert the file.
                 if not dry_run:
                     output_path = generate_output_path(input_path)
                     convert_to_h265(input_path, output_path)
+                # Keep track of the total data size.
                 actual_data_size += os.stat(input_path).st_size
+                # Stop processing files once we've reached our target data size.
                 if actual_data_size > target_data_size:
                     break
         except ffmpy.FFRuntimeError:


### PR DESCRIPTION
closes #3 .  Leverage `click` library to implement common cli patterns:

1. Add `--help` flag.
1. Treat `directory` as a positional parameter.  Required.
1. Treat `dry-run` as a switch (no off-switch), so the default is a real run.

![image](https://user-images.githubusercontent.com/1740566/232973605-4e62e006-53bc-40d3-90de-7a605bb01f03.png)
