### PR TITLE
Update development doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,32 @@
+# Development
+
+Clone this repository.
+
+Create a virtual environment, for example, directory `venv` using Python's `venv` module.
+```
+python -m venv venv
+```
+
+Activate the new environment with:
+```
+source ./venv/bin/activate
+```
+
+Make sure the latest pip version is in your virtual environment:
+```
+pip install --upgrade pip
+```
+
+Install all dependencies:
+```
+pip install -e ".[dev]"
+```
+
+Test run cli tool:
+```
+make-room --help
+```
+
 # Usage
 
 To run the `make_room.py` script:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,9 +53,6 @@ make-room = "make_room:main"
 [tool.hatch.version]
 path = "src/make_room/__init__.py"
 
-[tool.hatch.envs.default]
-features = ["dev"]
-
 [tool.ruff]
 line-length = 120
 select = [


### PR DESCRIPTION
Follow fastapi [contributing guide](https://fastapi.tiangolo.com/contributing/) to make development setup doc more verbose.  Basically this keeps things simple by creating virtual envs manually without relying on `hatch` to manage environments (such as using `hatch shell`).  If a more complicated environment management scheme is needed, we can add back later.